### PR TITLE
Update get_sunrise_sunset() to cover full AI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GAPsurvey
 Type: Package
 Title: Provides at-sea data management tools for RACE GAP surveys
-Version: 2024.04.01
+Version: 2024.04.04
 License: GPL-3
 Authors@R: 
   c(person(given = "Emily",

--- a/inst/r/example_script.R
+++ b/inst/r/example_script.R
@@ -38,9 +38,26 @@ get_catch_haul_history(
 ## Learn more about and find examples for functions in GAPsurvey using...
 # ?get_sunrise_sunset
 
+get_sunrise_sunset(chosen_date = "2024-06-10",
+                   survey = "AI",
+                   station = "33-47")
+
 get_sunrise_sunset(chosen_date = Sys.Date(),
-                  survey = "EBS",
-                  station = "I-13")
+                   survey = "GOA",
+                   station = "323-176")
+
+get_sunrise_sunset(chosen_date = "2024-08-04",
+                   survey = "EBS",
+                   station = "P-31")
+
+get_sunrise_sunset(chosen_date = "2024-06-04",
+                   survey = "NBS",
+                   station = "ZZ-01")
+
+get_sunrise_sunset(chosen_date = "2024-08-04",
+                   survey = NULL,
+                   latitude = 60,
+                   longitude = -162)
 
 ## other examples:
 # get_sunrise_sunset(chosen_date = "2023-06-10",

--- a/inst/r/run.R
+++ b/inst/r/run.R
@@ -135,11 +135,12 @@ stn_col <- c("ID", "ID", "STATIONID", "STATIONID")
 station_coords <- data.frame()
 
 for(ii in 1:length(sel_region)) {
-  map_layers <- akgfmaps::get_base_layers(select.region = sel_region[ii], set.crs = "EPSG:4326")
+  map_layers <- akgfmaps::get_base_layers(select.region = sel_region[ii], set.crs = "EPSG:3338")
 
   station_center <- map_layers$survey.grid |>
     sf::st_make_valid() |>
-    sf::st_centroid()
+    sf::st_centroid() |>
+    sf::st_transform(crs = "WGS84")
 
   station_center <- data.frame(station = station_center[[stn_col[ii]]]) |>
     dplyr::bind_cols(sf::st_coordinates(station_center)) |>

--- a/man/get_sunrise_sunset.Rd
+++ b/man/get_sunrise_sunset.Rd
@@ -59,7 +59,7 @@ get_sunrise_sunset(chosen_date = Sys.Date(),
                    survey = "GOA",
                    station = "323-176")
 # Find times based on a survey (AI) station's recorded lat/lon for today's date
-# get_sunrise_sunset(chosen_date = "2023-06-10",
-#                     survey = "AI",
-#                    station = "33-47")
+get_sunrise_sunset(chosen_date = "2023-06-10",
+                    survey = "AI",
+                   station = "33-47")
 }


### PR DESCRIPTION
Revised get_sunrise_sunset() to work in the Eastern Hemisphere and added more usage examples to example_script.R.

I didn't regenerate docs with run.R since Z:/Projects/ConnectToOracle.R is private.

Closes #19
Closes #14 ([c50146a](https://github.com/afsc-gap-products/GAPsurvey/pull/22/commits/c50146aad3ece32aa8eff7c468fa90e83a0ca5a1))

