### PR TITLE
Minor updates/bug fix to convert_log_gps()

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -191,7 +191,7 @@ convert_ted_btd <- function(
 #' @param path_out Optional. The default is the local working directory but may be specified with a string.
 #' @param filename_add Optional. Default = "new". This string will be added to the name of the outputted file. Here, you can additional information that may make this file helpful to find later.
 #'
-#' @return A .GPS file to the path_out directory.
+#' @return A .GPS file to the path_out directory with DATE/TIME in AKDT.
 #' @export
 #'
 #' @examples
@@ -256,8 +256,8 @@ convert_log_gps <- function(
   colnames(infoselect)<-c("VESSEL","CRUISE","HAUL","DATE","TIME","LAT1","LAT2","LONG1","LONG2")
   # head(infoselect)
 
-  tstamp <- as.numeric(infoselect$TIME) # sometimes this reads as chr and sometimes as num so force to num
-  tstamp <- sprintf("%06d", tstamp) # add leading zeroes
+  tstamp <- as.character(infoselect$TIME) # sometimes this reads as chr and sometimes as num so force to chr
+  tstamp <- sprintf("%06s", tstamp) # add leading zeroes
   hh = as.numeric(substr(tstamp, start = 1, stop = 2))
   hh=ifelse(hh<8,hh+24,hh)-8 # convert to AKDT
   #hh=ifelse(hh<10,paste0(0,hh),as.character(hh))

--- a/R/functions.R
+++ b/R/functions.R
@@ -260,7 +260,7 @@ convert_log_gps <- function(
   tstamp <- sprintf("%06d", tstamp) # add leading zeroes
   hh = as.numeric(substr(tstamp, start = 1, stop = 2))
   hh=ifelse(hh<8,hh+24,hh)-8 # convert to AKDT
-  hh=ifelse(hh<10,paste0(0,hh),as.character(hh))
+  #hh=ifelse(hh<10,paste0(0,hh),as.character(hh))
   mm=substr(tstamp,start=3, stop=4)
   ss=substr(tstamp,start=5, stop=6)
   DATE_TIME=paste(infoselect$"DATE", paste(hh,mm,ss,sep=":"))

--- a/R/functions.R
+++ b/R/functions.R
@@ -256,13 +256,13 @@ convert_log_gps <- function(
   colnames(infoselect)<-c("VESSEL","CRUISE","HAUL","DATE","TIME","LAT1","LAT2","LONG1","LONG2")
   # head(infoselect)
 
-  hh <- as.numeric(infoselect$TIME) # sometimes this reads as chr and sometimes as num so force to num
-  hh <- sprintf("%06d", hh) # add leading zeroes
-  hh = as.numeric(substr(hh2, start = 1, stop = 2))
+  tstamp <- as.numeric(infoselect$TIME) # sometimes this reads as chr and sometimes as num so force to num
+  tstamp <- sprintf("%06d", tstamp) # add leading zeroes
+  hh = as.numeric(substr(tstamp, start = 1, stop = 2))
   hh=ifelse(hh<8,hh+24,hh)-8 # convert to AKDT
   hh=ifelse(hh<10,paste0(0,hh),as.character(hh))
-  mm=substr(infoselect$"TIME",start=3, stop=4)
-  ss=substr(infoselect$"TIME",start=5, stop=6)
+  mm=substr(tstamp,start=3, stop=4)
+  ss=substr(tstamp,start=5, stop=6)
   DATE_TIME=paste(infoselect$"DATE", paste(hh,mm,ss,sep=":"))
 
   lat1=as.numeric(as.character(infoselect$LAT1))
@@ -282,7 +282,7 @@ convert_log_gps <- function(
                      ".gps")
 
   new_gps1<-new_gps
-  names(new_gps1) <- NULL
+  #names(new_gps1) <- NULL
   new_gps1 <- as.matrix(new_gps1)
 
   utils::write.table(x = new_gps1,
@@ -290,7 +290,7 @@ convert_log_gps <- function(
                      quote=FALSE,
                      sep = ",",
                      row.names=FALSE,
-                     col.names = FALSE,
+                     col.names = TRUE,
                      eol="\n")
 
   message(paste0("Your new .gps files are saved to ", filename))

--- a/R/functions.R
+++ b/R/functions.R
@@ -229,12 +229,19 @@ convert_log_gps <- function(
     DATE = NA,
     path_in,
     path_out = "./",
-    filename_add = ""){
-
-  if (is.na(VESSEL)){ VESSEL <- readline("Type vessel code:  ") }
-  if (is.na(CRUISE)){ CRUISE <- readline("Type cruise number:  ") }
-  if (is.na(HAUL)){ HAUL <- readline("Type haul number:  ") }
-  if (is.na(DATE)){ DATE <- readline("Type date of haul (MM/DD/YYYY):  ") }
+    filename_add = "") {
+  if (is.na(VESSEL)) {
+    VESSEL <- readline("Type vessel code:  ")
+  }
+  if (is.na(CRUISE)) {
+    CRUISE <- readline("Type cruise number:  ")
+  }
+  if (is.na(HAUL)) {
+    HAUL <- readline("Type haul number:  ")
+  }
+  if (is.na(DATE)) {
+    DATE <- readline("Type date of haul (MM/DD/YYYY):  ")
+  }
 
   path_in <- fix_path(path_in)
   file.name <- path_in
@@ -245,52 +252,57 @@ convert_log_gps <- function(
   HAUL <- as.numeric(HAUL)
   shaul <- numbers0(x = HAUL, number_places = 4)
 
-  log.file<-utils::read.csv(file.name,header=F, sep=",")
+  log.file <- utils::read.csv(file.name, header = F, sep = ",")
 
-  only.GPRMC<-log.file[log.file$V1=="$GPRMC",]
+  only.GPRMC <- log.file[log.file$V1 == "$GPRMC", ]
   # head(only.GPRMC)
-  only.GPRMC<-only.GPRMC[,c(2,4,5,6,7)]
+  only.GPRMC <- only.GPRMC[, c(2, 4, 5, 6, 7)]
   # head(only.GPRMC)
-  info<-cbind(VESSEL, CRUISE, HAUL, DATE)
-  infoselect<-cbind(info,only.GPRMC)
-  colnames(infoselect)<-c("VESSEL","CRUISE","HAUL","DATE","TIME","LAT1","LAT2","LONG1","LONG2")
+  info <- cbind(VESSEL, CRUISE, HAUL, DATE)
+  infoselect <- cbind(info, only.GPRMC)
+  colnames(infoselect) <- c("VESSEL", "CRUISE", "HAUL", "DATE", "TIME", "LAT1", "LAT2", "LONG1", "LONG2")
   # head(infoselect)
 
   tstamp <- round(as.numeric(infoselect$TIME)) # sometimes this reads as chr and sometimes as num so force to num. Sometimes a decimal timestamp will break it if you don't round.
   tstamp <- sprintf("%06d", tstamp) # add leading zeroes
-  hh = as.numeric(substr(tstamp, start = 1, stop = 2))
-  hh=ifelse(hh<8,hh+24,hh)-8 # convert to AKDT
-  mm=substr(tstamp,start=3, stop=4)
-  ss=substr(tstamp,start=5, stop=6)
-  DATE_TIME=paste(infoselect$"DATE", paste(hh,mm,ss,sep=":"))
+  hh <- as.numeric(substr(tstamp, start = 1, stop = 2))
+  hh <- ifelse(hh < 8, hh + 24, hh) - 8 # convert to AKDT
+  mm <- substr(tstamp, start = 3, stop = 4)
+  ss <- substr(tstamp, start = 5, stop = 6)
+  DATE_TIME <- paste(infoselect$"DATE", paste(hh, mm, ss, sep = ":"))
 
-  lat1=as.numeric(as.character(infoselect$LAT1))
-  LAT=ifelse(infoselect$"LAT2"=="N",lat1,-lat1)
+  lat1 <- as.numeric(as.character(infoselect$LAT1))
+  LAT <- ifelse(infoselect$"LAT2" == "N", lat1, -lat1)
   LAT <- formatC(x = LAT, digits = 4, format = "f")
 
-  long1=as.numeric(as.character(infoselect$LONG1))
-  LONG=ifelse(infoselect$"LONG2"=="E",long1,-long1)
+  long1 <- as.numeric(as.character(infoselect$LONG1))
+  LONG <- ifelse(infoselect$"LONG2" == "E", long1, -long1)
   LONG <- formatC(x = LONG, digits = 4, format = "f")
 
   new_gps <- cbind.data.frame(VESSEL, CRUISE, HAUL, DATE_TIME, LAT, LONG)
 
 
-  filename <- paste0(path_out, "HAUL",shaul,
-                     ifelse(is.na(filename_add) | filename_add == "",
-                            "", paste0("_", filename_add)),
-                     ".gps")
+  filename <- paste0(
+    path_out, "HAUL", shaul,
+    ifelse(is.na(filename_add) | filename_add == "",
+      "", paste0("_", filename_add)
+    ),
+    ".gps"
+  )
 
-  new_gps1<-new_gps
-  #names(new_gps1) <- NULL
+  new_gps1 <- new_gps
+  # names(new_gps1) <- NULL
   new_gps1 <- as.matrix(new_gps1)
 
-  utils::write.table(x = new_gps1,
-                     file = filename,
-                     quote=FALSE,
-                     sep = ",",
-                     row.names=FALSE,
-                     col.names = TRUE,
-                     eol="\n")
+  utils::write.table(
+    x = new_gps1,
+    file = filename,
+    quote = FALSE,
+    sep = ",",
+    row.names = FALSE,
+    col.names = TRUE,
+    eol = "\n"
+  )
 
   message(paste0("Your new .gps files are saved to ", filename))
 }

--- a/R/functions.R
+++ b/R/functions.R
@@ -256,11 +256,10 @@ convert_log_gps <- function(
   colnames(infoselect)<-c("VESSEL","CRUISE","HAUL","DATE","TIME","LAT1","LAT2","LONG1","LONG2")
   # head(infoselect)
 
-  tstamp <- as.character(infoselect$TIME) # sometimes this reads as chr and sometimes as num so force to chr
-  tstamp <- sprintf("%06s", tstamp) # add leading zeroes
+  tstamp <- round(as.numeric(infoselect$TIME)) # sometimes this reads as chr and sometimes as num so force to num. Sometimes a decimal timestamp will break it if you don't round.
+  tstamp <- sprintf("%06d", tstamp) # add leading zeroes
   hh = as.numeric(substr(tstamp, start = 1, stop = 2))
   hh=ifelse(hh<8,hh+24,hh)-8 # convert to AKDT
-  #hh=ifelse(hh<10,paste0(0,hh),as.character(hh))
   mm=substr(tstamp,start=3, stop=4)
   ss=substr(tstamp,start=5, stop=6)
   DATE_TIME=paste(infoselect$"DATE", paste(hh,mm,ss,sep=":"))

--- a/R/functions.R
+++ b/R/functions.R
@@ -256,8 +256,10 @@ convert_log_gps <- function(
   colnames(infoselect)<-c("VESSEL","CRUISE","HAUL","DATE","TIME","LAT1","LAT2","LONG1","LONG2")
   # head(infoselect)
 
-  hh=as.numeric(substr(infoselect$"TIME",start=1, stop=2))
-  hh=ifelse(hh<8,hh+24,hh)-8
+  hh <- as.numeric(infoselect$TIME) # sometimes this reads as chr and sometimes as num so force to num
+  hh <- sprintf("%06d", hh) # add leading zeroes
+  hh = as.numeric(substr(hh2, start = 1, stop = 2))
+  hh=ifelse(hh<8,hh+24,hh)-8 # convert to AKDT
   hh=ifelse(hh<10,paste0(0,hh),as.character(hh))
   mm=substr(infoselect$"TIME",start=3, stop=4)
   ss=substr(infoselect$"TIME",start=5, stop=6)


### PR DESCRIPTION
I tried to use `convert_log_gps()` to recover some GPS data this year and found/fixed:
1) sometimes the .log data read in with time as numeric and sometimes they don't. I fixed this by forcing it to numeric in any case, and manually adding leading zeroes to single-digit hours with `sprintf()` instead of using `paste()`. 
2) The regular function was not consistently producing a header row; I changed it so that the resulting .gps file has the expected header

I think that's all for now, though I'm using a lot of these functions this week so there may be another imminent pull request :)