### PR TITLE
Fix timezone bug for older versions of R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GAPsurvey
 Type: Package
 Title: Provides at-sea data management tools for RACE GAP surveys
-Version: 2025.06.07
+Version: 2025.08.06
 License: GPL-3
 Authors@R: 
   c(person(given = "Emily",

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,7 @@
+GAPsurvey 2025.08.06 (August 6, 2025)
+----------------------------------------------------------------
+
+BUG FIX
+
+- Changed approach to timezone conversion in convert_nmea_btd()
+  to prevent incorrect times in R < 4.3.0.

--- a/R/functions.R
+++ b/R/functions.R
@@ -646,9 +646,8 @@ convert_nmea_btd <- function(nmea_strings = NULL, filter_type = "none", interact
     rownames(output_btd) <- NULL
 
     # Convert DATE_TIME to Alaska time and format for .BTD
-    output_btd$DATE_TIME <- as.POSIXct(output_btd$DATE_TIME, tz = "UTC")
-    output_btd$DATE_TIME <- as.POSIXct(output_btd$DATE_TIME, tz = "America/Anchorage")
-
+    attr(output_btd$DATE_TIME, "tzone") <- "UTC"
+    attr(output_btd$DATE_TIME, "tzone") <- "America/Anchorage"
 
     # Write .BTH file
     output_bth <-


### PR DESCRIPTION
create_nmea_btd() did not work correctly with R < 4.3.0 because time zone handling in as.POSIXct(tz = {timezone}) changed in 4.3.0. This update ensures compatibility with older releases.